### PR TITLE
Updating this sample to target a profile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ### Downloads and Subscriptions
 This sample assumes that you have an Azure subscription to target. If you do not already have one, you can get started for free at [azure.microsoft.com](https://azure.microsoft.com/en-us/free/). 
 
-You should also have a machine with [Go 1.7](https://golang.org/dl/) or higher installed.
+You should also have a machine with [Go 1.9](https://golang.org/dl/) or higher installed.
 
 ### System Environment
 You will need to have the following environment variables set when executing this sample:

--- a/glide.lock
+++ b/glide.lock
@@ -1,20 +1,24 @@
-hash: da15ed6ed1efd6f2e8dd9b0b56c63ed32397c3880e3a3b65c72298ea03933146
-updated: 2017-09-29T11:48:01.3791216-07:00
+hash: a6b0ca6fe54ccfa4581820d4402a77c5cc9665ef88fec12bc17bf421512017bb
+updated: 2017-10-20T10:51:57.5204416-07:00
 imports:
 - name: github.com/Azure/azure-sdk-for-go
-  version: 2592daf71ab6b95dcfc7f7437ecc1afb9ddb7360
+  version: 09b7f75d0b75dab01d5152a968422915e4cb76ce
   subpackages:
   - arm/network
   - arm/resources/resources
+  - profiles/2017-03-09/network/mgmt/network
+  - profiles/2017-03-09/resources/mgmt/resources
+  - services/network/mgmt/2017-09-01/network
+  - services/resources/mgmt/2017-05-10/resources
 - name: github.com/Azure/go-autorest
   version: f6be1abbb5abd0517522f850dd785990d373da7e
   subpackages:
   - autorest/azure
   - autorest
+  - autorest/adal
   - autorest/to
   - autorest/date
   - autorest/validation
-  - autorest/adal
 - name: github.com/dgrijalva/jwt-go
   version: a539ee1a749a2b895533f979515ac7e6e0f5b650
 - name: github.com/marstr/guid

--- a/glide.lock
+++ b/glide.lock
@@ -1,26 +1,26 @@
-hash: a6b0ca6fe54ccfa4581820d4402a77c5cc9665ef88fec12bc17bf421512017bb
-updated: 2017-10-20T10:51:57.5204416-07:00
+hash: c647f108a4f69cc1b0844336d29ea0b9377c954e03c52afdd09e3bb01784201d
+updated: 2017-11-07T09:39:07.4388644-08:00
 imports:
 - name: github.com/Azure/azure-sdk-for-go
-  version: 09b7f75d0b75dab01d5152a968422915e4cb76ce
+  version: 153d3422c65465edfcdbf2ce1707b35ab3891845
   subpackages:
-  - arm/network
-  - arm/resources/resources
+  - github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/network/mgmt/network
+  - github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/resources
   - profiles/2017-03-09/network/mgmt/network
   - profiles/2017-03-09/resources/mgmt/resources
-  - services/network/mgmt/2017-09-01/network
-  - services/resources/mgmt/2017-05-10/resources
+  - services/network/mgmt/2015-06-15/network
+  - services/resources/mgmt/2016-02-01/resources
 - name: github.com/Azure/go-autorest
-  version: f6be1abbb5abd0517522f850dd785990d373da7e
+  version: 8efdaa3a898515764e6039c03e8d953c10519915
   subpackages:
-  - autorest/azure
   - autorest
-  - autorest/adal
-  - autorest/to
+  - autorest/azure
   - autorest/date
+  - autorest/to
+  - autorest/adal
   - autorest/validation
 - name: github.com/dgrijalva/jwt-go
-  version: a539ee1a749a2b895533f979515ac7e6e0f5b650
+  version: dbeaa9332f19a944acb5736b4456cfcc02140e29
 - name: github.com/marstr/guid
   version: 8926f83764578dfb6b5017223c12135cbc967a20
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,13 +1,9 @@
 package: github.com/Azure-Samples/network-go-manage-network-security-group
 import:
 - package: github.com/Azure/azure-sdk-for-go
-  version: dev
+  version: ^v11.2.0-beta
   subpackages:
-  - arm/network
-  - arm/resources/resources
-- package: github.com/Azure/go-autorest
-  version: ~8.4.0
-  subpackages:
-  - autorest/azure
+  - github.com/Azure/azure-sdk-for-go/profiles/latest/network/mgmt/network
+  - github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources
 - package: github.com/marstr/guid
   version: ~0.2.1

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/Azure-Samples/network-go-manage-network-security-group
 import:
 - package: github.com/Azure/azure-sdk-for-go
-  version: ~11.0.0-beta
+  version: dev
   subpackages:
   - arm/network
   - arm/resources/resources

--- a/sample.go
+++ b/sample.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/arm/network"
-	"github.com/Azure/azure-sdk-for-go/arm/resources/resources"
+	"github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/network/mgmt/network"
+	"github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/resources"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"

--- a/sample.go
+++ b/sample.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/network/mgmt/network"
-	"github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/resources"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/network/mgmt/network"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"


### PR DESCRIPTION
To do this, and make it easy to just run this sample, I had to update
Glide to target the `dev` branch. This should be a temporary state, and
once profiles become mainstream, we should update glide.yaml to target a
release tag again.

Tareting a profile here both helps how how to use it, and makes our
samples more resilient to breaking changes in the future.